### PR TITLE
IN-9 fix: changed the button spelling using Slot

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@radix-ui/react-select": "^2.1.1",
     "@fontsource/inter": "^5.0.20",
+    "@radix-ui/react-select": "^2.1.1",
+    "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tabs": "^1.1.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@radix-ui/react-select':
         specifier: ^2.1.1
         version: 2.1.1(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot':
+        specifier: ^1.1.0
+        version: 1.1.0(@types/react@18.3.5)(react@18.3.1)
       '@radix-ui/react-tabs':
         specifier: ^1.1.0
         version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/src/shared/ui/Button/Button.stories.tsx
+++ b/src/shared/ui/Button/Button.stories.tsx
@@ -18,10 +18,9 @@ const meta: Meta<typeof Button> = {
       },
     },
   },
-  // Todo Спросить на проверке по поводу args в Meta. Плохо или хорошо, в чём разница
   args: {
     children: 'Button',
-    as: 'button',
+    asChild: false,
     disabled: false,
     className: '',
     fullWidth: false,
@@ -39,8 +38,6 @@ export const Primary: Story = {
 };
 export const Secondary: Story = {
   args: {
-    // Todo 1 из вариантов документации
-    ...Primary.args,
     variant: 'secondary',
   },
 };
@@ -68,10 +65,9 @@ export const FullWidth: Story = {
 export const AsLink: Story = {
   args: {
     variant: 'outline',
-    as: 'a',
-    href: '/'
+    asChild: true
   },
   render: (args) => {
-    return <Button {...args}>Button as Link</Button>
+    return <Button {...args}><a>Button as Link</a></Button>
   }
 };

--- a/src/shared/ui/Button/Button.tsx
+++ b/src/shared/ui/Button/Button.tsx
@@ -2,15 +2,16 @@ import { cn } from '@/features/utils/cn';
 import { VariantProps } from 'class-variance-authority';
 import React, { ComponentProps, ElementType } from 'react';
 import { buttonVariants } from '.';
+import { Slot } from '@radix-ui/react-slot';
 
-type Props<E extends ElementType> = ComponentProps<E>
+type Props = ComponentProps<'button'>
     & VariantProps<typeof buttonVariants>
-    & { as?: E, href?: string, fullWidth?: boolean }
+    & { asChild?: boolean, fullWidth?: boolean }
 
-export const Button = <E extends ElementType = 'button'>({
-    variant = 'primary', className, as, fullWidth = false, ...props
-}: Props<E>) => {
-    const Component = as || 'button';
+export const Button = ({
+    variant = 'primary', className, asChild = false, fullWidth = false, ...props
+}: Props) => {
+    const Component = asChild ? Slot : "button"
 
     return (
         <Component


### PR DESCRIPTION
- удаляет as и href из props Button
- добавляет новый импорт radix/react-slot для работоспособности кнопки
- добавляет asChild как необязательный props для Button
- меняет написание кнопки для создания ссылки (пример в storybook)